### PR TITLE
Make "day-of-month" behavior more consistent

### DIFF
--- a/src/clj_cron_parse/core.clj
+++ b/src/clj_cron_parse/core.clj
@@ -231,7 +231,9 @@
     :W (next-week-dom now)
     ([& xs] :seq) (if-let [ns (next-val (t/day now) xs)]
                     (t/plus now (t/days (- ns (t/day now))))
-                    (t/plus now (t/months 1) (t/days (- (first xs) (t/day now)))))
+                    (t/plus (t/minus now (t/days (- (t/day now) 1)))
+                            (t/months 1)
+                            (t/days (- (first xs) 1))))
     {:range x} (t/plus now (t/days 1))
     :else now))
 

--- a/test/clj_cron_parse/core_test.clj
+++ b/test/clj_cron_parse/core_test.clj
@@ -76,7 +76,10 @@
              (next-date now "@midnight") => (date 2015 01 02 00 00 00 000)
              (next-date now "@hourly") => (date 2015 01 01 13 00 00 000)
              (next-date (t/date-time 2015 04 22 06 22 29 000) "30 22 6 * * 3") => (date 2015 04 22 06 22 30 000)
-             (next-date (t/date-time 2015 04 21 06 22 30 000) "30 22 6 * * 3") => (date 2015 04 22 06 22 30 000)))
+             (next-date (t/date-time 2015 04 21 06 22 30 000) "30 22 6 * * 3") => (date 2015 04 22 06 22 30 000)
+             (next-date (t/date-time 2020 01 29 00 00 00 000) "0 0 0 1 * *") => (date 2020 02 01 00 00 00 000)
+             (next-date (t/date-time 2020 01 30 00 00 00 000) "0 0 0 1 * *") => (date 2020 02 01 00 00 00 000)
+             (next-date (t/date-time 2020 01 31 00 00 00 000) "0 0 0 1 * *") => (date 2020 02 01 00 00 00 000)))
 
 ;; TODO: close to new year, combinations, range/n for dow
 


### PR DESCRIPTION
Previously, the "day-of-month" behavior was broken at the end of the
month during long months before short months -- e.g. on January 30th if
you asked for Febuary 1st, it would return January 30th.

This makes it more consistent by setting the day of month to 1, then
adding a month, then adding (requested date - 1) days.

This is still broken if you ask for e.g. February 31st, but that is out
of scope of this PR.